### PR TITLE
Add `slf4j` dependency to fix build related errors when running `ZksCryptoTest`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,16 @@
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.6.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Fixes:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

while running `ZksCryptoTest` in IntelliJ IDEA.